### PR TITLE
Add option for channel 'whitelisting' (solves #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ By default, a user is considered active if they have said something in the last 
 - To run automatically, create a symlink to `smartfilter.pl` in your `.irssi/scripts/autorun` directory
 - Optionally change the recent activity time (in seconds): `/set smartfilter_delay 1200`
 - Old nicks are removed from memory periodically. You can change how often the garbage collection runs by doing (how many smartfilter-delays it waits): `/set smartfilter_garbage_multiplier 4`
+- You can specify a space-separated list of channels for which the filtering will be disabled: `/set smartfilter_ignored_chans #channel1 #channel2`
 
 ## Contributors
 [Christian Brassat](http://crshd.anapnea.net/2012/10/03/Smartfilter-for-Irssi/), [Niall Bunting](http://niallbunting.com/) and [Walter Hop](https://lifeforms.nl/)

--- a/smartfilter.pl
+++ b/smartfilter.pl
@@ -6,7 +6,7 @@ use vars qw($VERSION %IRSSI);
 $VERSION = "0.4";
 
 %IRSSI = (
-	authors     => 'Christian Brassat, Niall Bunting and Walter Hop',
+	authors     => 'Christian Brassat, Niall Bunting, Walter Hop and Frantisek Sumsal',
 	contact     => 'irssi-smartfilter@spam.lifeforms.nl',
 	name        => 'smartfilter.pl',
 	description => 'Improved smart filter for join, part, quit, nick messages',

--- a/smartfilter.pl
+++ b/smartfilter.pl
@@ -75,7 +75,10 @@ sub smartfilter_quit {
 # NICK change received.
 sub smartfilter_nick {
 	my ($server, $newnick, $nick, $address) = @_;
-	&checkactive($nick, $newnick, undef);
+
+	if (Irssi::settings_get_bool('smartfilter_filter_nick')) {
+		&checkactive($nick, $newnick, undef);
+	}
 };
 
 # Channel message received. Mark the nick as active.
@@ -93,3 +96,4 @@ Irssi::signal_add('message nick', 'smartfilter_nick');
 Irssi::settings_add_int('smartfilter', 'smartfilter_garbage_multiplier', 4);
 Irssi::settings_add_int('smartfilter', 'smartfilter_delay', 1200);
 Irssi::settings_add_str('smartfilter', 'smartfilter_ignored_chans', '');
+Irssi::settings_add_bool('smartfilter', 'smartfilter_filter_nick', 1);

--- a/smartfilter.pl
+++ b/smartfilter.pl
@@ -34,13 +34,19 @@ sub checkactive {
 		return;
 	}
 
-	if (exists $lastmsg->{$nick} && $lastmsg->{$nick} <= time() - Irssi::settings_get_int('smartfilter_delay')) {
+	my $isfirst = !exists $lastmsg->{$nick};
+
+	if (!$isfirst && $lastmsg->{$nick} <= time() - Irssi::settings_get_int('smartfilter_delay')) {
 		delete $lastmsg->{$nick};
 		Irssi::signal_stop();
 	} else {
 		$lastmsg->{$nick} = time();
 		if ($altnick) {
 			$lastmsg->{$altnick} = time();
+		}
+
+		if ($isfirst) {
+			Irssi::signal_stop();
 		}
 	}
 

--- a/smartfilter.pl
+++ b/smartfilter.pl
@@ -1,4 +1,5 @@
 use strict;
+use warnings;
 use Irssi;
 use vars qw($VERSION %IRSSI);
 
@@ -28,11 +29,12 @@ sub checkactive {
 	my $ignored_chans = Irssi::settings_get_str('smartfilter_ignored_chans');
 	my @ignored_chans_array = split /\s+/, $ignored_chans;
 
-	if(defined $channel && grep(/$channel/, @ignored_chans_array)) {
+	# Skip filtering if current channel is in 'smartfilter_ignored_chans'
+	if (defined $channel && grep(/$channel/, @ignored_chans_array)) {
 		return;
 	}
 
-	if ($lastmsg->{$nick} <= time() - Irssi::settings_get_int('smartfilter_delay')) {
+	if (exists $lastmsg->{$nick} && $lastmsg->{$nick} <= time() - Irssi::settings_get_int('smartfilter_delay')) {
 		delete $lastmsg->{$nick};
 		Irssi::signal_stop();
 	} else {
@@ -51,10 +53,9 @@ sub checkactive {
 
 # Implements garbage collection.
 sub garbagecollect{
-	my ($key) = @_;
-	foreach ($lastmsg->{$key}) {
+	foreach my $key (keys %$lastmsg) {
 		if ($lastmsg->{$key} <= time() - Irssi::settings_get_int('smartfilter_delay')) {
-                        delete $lastmsg->{$key}
+			delete $lastmsg->{$key}
 		}
 	}
 }

--- a/smartfilter.pl
+++ b/smartfilter.pl
@@ -80,6 +80,12 @@ sub smartfilter_text {
 	}
 }
 
+sub smartfilter_settings {
+	undef @ignored_chans if @ignored_chans;
+	my $ign_chans = Irssi::settings_get_str('smartfilter_ignored_chans');
+	@ignored_chans = split /\s+/, $ign_chans;
+}
+
 # Channel message received. Mark the nick as active.
 sub log {
 	my ($server, $msg, $nick, $address, $target) = @_;
@@ -90,10 +96,10 @@ Irssi::signal_add('message public', 'log');
 Irssi::signal_add('message join', 'smartfilter_chan');
 Irssi::signal_add('message part', 'smartfilter_chan');
 Irssi::signal_add('print text', 'smartfilter_text');
+Irssi::signal_add('setup changed', 'smartfilter_settings');
 
 Irssi::settings_add_int('smartfilter', 'smartfilter_garbage_multiplier', 4);
 Irssi::settings_add_int('smartfilter', 'smartfilter_delay', 1200);
 Irssi::settings_add_str('smartfilter', 'smartfilter_ignored_chans', '');
 
-my $ign_chans = Irssi::settings_get_str('smartfilter_ignored_chans');
-@ignored_chans = split /\s+/, $ign_chans;
+smartfilter_settings();

--- a/smartfilter.pl
+++ b/smartfilter.pl
@@ -74,8 +74,8 @@ sub smartfilter_chan {
 
 # QUIT received.
 sub smartfilter_quit {
-	my ($channel, $nick, $address, $reason) = @_;
-	&checkactive($nick, undef, $channel);
+	my ($server, $nick, $address, $reason) = @_;
+	&checkactive($nick, undef, undef);
 };
 
 # NICK change received.

--- a/smartfilter.pl
+++ b/smartfilter.pl
@@ -18,6 +18,7 @@ $VERSION = "0.4";
 # Associative array of nick => last active unixtime
 our $lastmsg = {};
 our $garbagetime = 1;
+our @ignored_chans;
 
 # Do checks after receving a channel event.
 # - If the originating nick is not active, ignore the signal.
@@ -26,28 +27,15 @@ our $garbagetime = 1;
 #   or QUIT, a second nick change, etc.
 sub checkactive {
 	my ($nick, $altnick, $channel) = @_;
-	my $ignored_chans = Irssi::settings_get_str('smartfilter_ignored_chans');
-	my @ignored_chans_array = split /\s+/, $ignored_chans;
 
 	# Skip filtering if current channel is in 'smartfilter_ignored_chans'
-	if (defined $channel && grep(/$channel/, @ignored_chans_array)) {
+	if (defined $channel && grep {$_ eq $channel} @ignored_chans) {
 		return;
 	}
 
-	my $isfirst = !exists $lastmsg->{$nick};
-
-	if (!$isfirst && $lastmsg->{$nick} <= time() - Irssi::settings_get_int('smartfilter_delay')) {
+	if (!exists $lastmsg->{$nick} || $lastmsg->{$nick} <= time() - Irssi::settings_get_int('smartfilter_delay')) {
 		delete $lastmsg->{$nick};
 		Irssi::signal_stop();
-	} else {
-		$lastmsg->{$nick} = time();
-		if ($altnick) {
-			$lastmsg->{$altnick} = time();
-		}
-
-		if ($isfirst) {
-			Irssi::signal_stop();
-		}
 	}
 
 	# Run the garbage collection every interval.
@@ -75,7 +63,10 @@ sub smartfilter_chan {
 # QUIT received.
 sub smartfilter_quit {
 	my ($server, $nick, $address, $reason) = @_;
-	&checkactive($nick, undef, undef);
+
+	if (Irssi::settings_get_bool('smartfilter_filter_quit')) {
+		&checkactive($nick, undef, undef);
+	}
 };
 
 # NICK change received.
@@ -103,3 +94,7 @@ Irssi::settings_add_int('smartfilter', 'smartfilter_garbage_multiplier', 4);
 Irssi::settings_add_int('smartfilter', 'smartfilter_delay', 1200);
 Irssi::settings_add_str('smartfilter', 'smartfilter_ignored_chans', '');
 Irssi::settings_add_bool('smartfilter', 'smartfilter_filter_nick', 1);
+Irssi::settings_add_bool('smartfilter', 'smartfilter_filter_quit', 1);
+
+my $ign_chans = Irssi::settings_get_str('smartfilter_ignored_chans');
+@ignored_chans = split /\s+/, $ign_chans;


### PR DESCRIPTION
This patch adds an option `smartfilter_ignored_chans` which can be used for specifying channels for which the join/part/quit/nick filtering will be skipped. It should solve the issue #3.
